### PR TITLE
Expose gzipped file contents

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,8 @@
     "require": {
         "php": ">=7.4",
         "async-aws/s3": "^1.5",
-        "psr/log": "^1.1|^2.0|^3.0"
+        "psr/log": "^1.1|^2.0|^3.0",
+        "ext-zlib": "*"
     },
     "require-dev": {
         "symfony/phpunit-bridge": "^5.4|^6.0"

--- a/composer.json
+++ b/composer.json
@@ -22,11 +22,12 @@
     },
     "require": {
         "php": ">=7.4",
+        "ext-zlib": "*",
         "async-aws/s3": "^1.5",
-        "psr/log": "^1.1|^2.0|^3.0",
-        "ext-zlib": "*"
+        "psr/log": "^1.1|^2.0|^3.0"
     },
     "require-dev": {
+        "ext-zip": "*",
         "symfony/phpunit-bridge": "^5.4|^6.0"
     }
 }

--- a/src/Archive.php
+++ b/src/Archive.php
@@ -1,6 +1,5 @@
 <?php
 
-
 namespace GromNaN\S3Zip;
 
 use GromNaN\S3Zip\Input\InputInterface;
@@ -8,7 +7,11 @@ use GromNaN\S3Zip\Input\InputInterface;
 class Archive
 {
     private InputInterface $input;
+
+    /** @var array<int, File> */
     private array $filesByIndex;
+
+    /** @var array<string, File> */
     private array $filesByName;
 
     public function __construct(InputInterface $input)
@@ -76,11 +79,17 @@ class Archive
         }
     }
 
+    /**
+     * @return string[]
+     */
     public function getFileNames(): array
     {
         return array_keys($this->filesByName);
     }
 
+    /**
+     * @return array<int, File>
+     */
     public function getFiles(): array
     {
         return $this->filesByIndex;

--- a/src/File.php
+++ b/src/File.php
@@ -1,6 +1,5 @@
 <?php
 
-
 namespace GromNaN\S3Zip;
 
 use GromNaN\S3Zip\Input\InputInterface;
@@ -42,5 +41,13 @@ class File
             +unpack('v', $chunk, 28)[1];
 
         return gzinflate(substr($chunk, $headerSize), $length);
+    }
+
+    /**
+     * @return resource
+     */
+    public function getUncompressedStream()
+    {
+        return $this->input->fetchStream($this->offset, $this->length, 'streaming file '.$this->name);
     }
 }

--- a/src/File.php
+++ b/src/File.php
@@ -13,6 +13,9 @@ class File
     private int $length;
     private array $options;
 
+    /**
+     * @internal
+     */
     public function __construct(InputInterface $input, array $options)
     {
         $this->input = $input;
@@ -32,7 +35,19 @@ class File
         return $this->options['index'];
     }
 
+    /**
+     * Reads and extract file contents
+     */
     public function getContents($length = 0): string
+    {
+        return gzinflate($this->fetch(), $length);
+    }
+
+    /**
+     * Reads compressed file contents.
+     * Binary result can be sent as gzipped HTTP response.
+     */
+    public function fetch(): string
     {
         $chunk = $this->input->fetch($this->offset, $this->length, 'reading file '.$this->name);
 
@@ -40,14 +55,6 @@ class File
             +unpack('v', $chunk, 26)[1]
             +unpack('v', $chunk, 28)[1];
 
-        return gzinflate(substr($chunk, $headerSize), $length);
-    }
-
-    /**
-     * @return resource
-     */
-    public function getUncompressedStream()
-    {
-        return $this->input->fetchStream($this->offset, $this->length, 'streaming file '.$this->name);
+        return substr($chunk, $headerSize);
     }
 }

--- a/src/Input/HttpInput.php
+++ b/src/Input/HttpInput.php
@@ -44,6 +44,14 @@ class HttpInput implements InputInterface
         return $res->getContent();
     }
 
+    /**
+     * {@inheritDoc}
+     */
+    public function fetchStream(int $start, int $length, string $reason)
+    {
+        throw new \BadMethodCallException('Not implemented');
+    }
+
     public function length(): int
     {
         $res = $this->httpClient->request('HEAD', $this->filename);

--- a/src/Input/HttpInput.php
+++ b/src/Input/HttpInput.php
@@ -1,6 +1,5 @@
 <?php
 
-
 namespace GromNaN\S3Zip\Input;
 
 use AsyncAws\S3\S3Client;
@@ -42,14 +41,6 @@ class HttpInput implements InputInterface
         ]);
 
         return $res->getContent();
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    public function fetchStream(int $start, int $length, string $reason)
-    {
-        throw new \BadMethodCallException('Not implemented');
     }
 
     public function length(): int

--- a/src/Input/InputInterface.php
+++ b/src/Input/InputInterface.php
@@ -1,16 +1,10 @@
 <?php
 
-
 namespace GromNaN\S3Zip\Input;
 
 interface InputInterface
 {
     public function fetch(int $start, int $length, string $reason): string;
-
-    /**
-     * @return resource
-     */
-    public function fetchStream(int $start, int $length, string $reason);
 
     public function length(): int;
 }

--- a/src/Input/InputInterface.php
+++ b/src/Input/InputInterface.php
@@ -7,5 +7,10 @@ interface InputInterface
 {
     public function fetch(int $start, int $length, string $reason): string;
 
+    /**
+     * @return resource
+     */
+    public function fetchStream(int $start, int $length, string $reason);
+
     public function length(): int;
 }

--- a/src/Input/LocalInput.php
+++ b/src/Input/LocalInput.php
@@ -28,18 +28,6 @@ class LocalInput implements InputInterface
         return fread($this->handle, $length);
     }
 
-    /**
-     * {@inheritDoc}
-     */
-    public function fetchStream(int $start, int $length, string $reason)
-    {
-        if (!rewind($this->handle)) {
-            throw new \Exception('Failed to rewind the stream');
-        }
-
-        return $this->handle;
-    }
-
     public function length(): int
     {
         return fstat($this->handle)['size'];

--- a/src/Input/LocalInput.php
+++ b/src/Input/LocalInput.php
@@ -1,18 +1,21 @@
 <?php
 
-
 namespace GromNaN\S3Zip\Input;
 
 class LocalInput implements InputInterface
 {
     private string $filename;
+
+    /**
+     * @var resource
+     */
     private $handle;
 
     public function __construct(string $filename)
     {
         $this->filename = $filename;
-        $handle = fopen($filename, 'r');
-        if (false === $filename) {
+        $handle = fopen($filename, 'rb');
+        if (false === $handle) {
             throw new \RuntimeException('File not found: '.$filename);
         }
         $this->handle = $handle;
@@ -23,6 +26,18 @@ class LocalInput implements InputInterface
         fseek($this->handle, $start);
 
         return fread($this->handle, $length);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function fetchStream(int $start, int $length, string $reason)
+    {
+        if (!rewind($this->handle)) {
+            throw new \Exception('Failed to rewind the stream');
+        }
+
+        return $this->handle;
     }
 
     public function length(): int

--- a/src/Input/S3Input.php
+++ b/src/Input/S3Input.php
@@ -48,6 +48,24 @@ class S3Input implements InputInterface
         return $res->getBody()->getContentAsString();
     }
 
+    /**
+     * {@inheritDoc}
+     */
+    public function fetchStream(int $start, int $length, string $reason)
+    {
+        $end = $start + $length - 1;
+
+        $this->logger->info(sprintf('Streaming bytes %d-%d from %s on %s as %s.', $start, $end, $this->key, $this->bucket, $reason));
+
+        $result = $this->s3->getObject([
+            'Bucket' => $this->bucket,
+            'Key' => $this->key,
+            'Range' => sprintf('bytes=%d-%d', $start, $end)
+        ]);
+
+        return $result->getBody()->getContentAsResource();
+    }
+
     public function length(): int
     {
         $res = $this->s3->headObject([

--- a/src/Input/S3Input.php
+++ b/src/Input/S3Input.php
@@ -1,6 +1,5 @@
 <?php
 
-
 namespace GromNaN\S3Zip\Input;
 
 use AsyncAws\S3\S3Client;
@@ -46,24 +45,6 @@ class S3Input implements InputInterface
         $res->resolve();
 
         return $res->getBody()->getContentAsString();
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    public function fetchStream(int $start, int $length, string $reason)
-    {
-        $end = $start + $length - 1;
-
-        $this->logger->info(sprintf('Streaming bytes %d-%d from %s on %s as %s.', $start, $end, $this->key, $this->bucket, $reason));
-
-        $result = $this->s3->getObject([
-            'Bucket' => $this->bucket,
-            'Key' => $this->key,
-            'Range' => sprintf('bytes=%d-%d', $start, $end)
-        ]);
-
-        return $result->getBody()->getContentAsResource();
     }
 
     public function length(): int

--- a/tests/Integration/ArchiveTest.php
+++ b/tests/Integration/ArchiveTest.php
@@ -1,6 +1,5 @@
 <?php
 
-
 namespace GromNaN\S3Zip\Tests\Integration;
 
 use GromNaN\S3Zip\Archive;
@@ -34,6 +33,10 @@ abstract class ArchiveTest extends TestCase
 
         $this->assertInstanceOf(File::class, $files[0]);
         $this->assertSame($files[5], $archive->getFile($files[5]->getName()));
+
+        $contents = $files[3]->getContents();
+        $compressedContents = $files[3]->fetch();
+        $this->assertSame($contents, gzinflate($compressedContents));
     }
 
     /**

--- a/tests/Integration/LocalArchiveTest.php
+++ b/tests/Integration/LocalArchiveTest.php
@@ -1,6 +1,5 @@
 <?php
 
-
 namespace GromNaN\S3Zip\Tests\Integration;
 
 use GromNaN\S3Zip\Input\InputInterface;

--- a/tests/Integration/S3ArchiveTest.php
+++ b/tests/Integration/S3ArchiveTest.php
@@ -1,6 +1,5 @@
 <?php
 
-
 namespace GromNaN\S3Zip\Tests\Integration;
 
 use AsyncAws\S3\S3Client;


### PR DESCRIPTION
In the context of serving a single file from an archive to an HTTP endpoint, the contents of the file don't need to be uncompressed with `gzinflate`. The browser/client is able to uncompress gzip contents itself.

Alternative to #3 